### PR TITLE
Require teardown >= 0.5

### DIFF
--- a/componentm-devel/package.yaml
+++ b/componentm-devel/package.yaml
@@ -28,7 +28,7 @@ ghc-options:
 dependencies:
 - base >=4.8 && <5
 - rio >= 0.0.3
-- teardown >= 0.3
+- teardown >= 0.5
 - componentm >= 0.0.0.2
 - foreign-store >= 0.2
 

--- a/componentm/package.yaml
+++ b/componentm/package.yaml
@@ -30,7 +30,7 @@ dependencies:
 - base >=4.8 && <5
 - rio >= 0.0.3
 - containers >= 0.5.7
-- teardown >= 0.3
+- teardown >= 0.5
 - prettyprinter >= 1.1
 - pretty-show >= 1.6.13
 


### PR DESCRIPTION
Previously versions >= 0.3 were permitted, but the project builds only
with teardown-0.5, otherwise I get
> No instance for (Pretty TeardownResult)